### PR TITLE
Removing initial movement lag

### DIFF
--- a/src/Run.java
+++ b/src/Run.java
@@ -1,3 +1,5 @@
+package pkgLab8;
+
 import java.awt.Color;
 
 import javax.swing.JFrame;
@@ -6,8 +8,8 @@ public class Run //Starts the animation sequence
 {
 	public static void main(String[] args) 
 	{
+		Images LOADIMAGES = Images.FIRE_EAST;//Loads the images so they don't have to load when the first button is pressed
     	Controller c1 = new Controller(); //Makes a new controller
 		c1.start(); //Start the animation
 	}
-
 }


### PR DESCRIPTION
Added a single line that calls the Images enum so the variables in the enum are already loaded the first time they need to be used and therefore don't lag on the first movement.